### PR TITLE
not implement Send and Sync traits for LocalApic

### DIFF
--- a/src/lapic/mod.rs
+++ b/src/lapic/mod.rs
@@ -329,3 +329,5 @@ impl LocalApic {
         self.regs.write_lvt_lint1(0);
     }
 }
+impl !Send for LocalApic {}
+impl !Sync for LocalApic {}


### PR DESCRIPTION
LocalApic is not safe to send between threads because when you setup the local apic it only sets up the apic of the current core, so if you send it to another core it will no longer work.