### PR TITLE
Encode and decode id from bits 31..24 for xapic mode

### DIFF
--- a/src/lapic/lapic_id.rs
+++ b/src/lapic/lapic_id.rs
@@ -1,0 +1,19 @@
+use super::LocalApicMode;
+
+/// In xAPIC, a local APIC's id is stored in bits 31..24.
+/// In x2APIC, a local APIC's id is stored as a normal u32.  
+pub fn decode_lapic_id(raw_id: u32, mode: LocalApicMode) -> u32 {
+    match mode {
+        LocalApicMode::XApic { xapic_base: _ } => raw_id >> 24,
+        LocalApicMode::X2Apic => raw_id,
+    }
+}
+
+/// In xAPIC, a local APIC's id is stored in bits 31..24.
+/// In x2APIC, a local APIC's id is stored as a normal u32.  
+pub fn encode_lapic_id(actual_id: u32, mode: LocalApicMode) -> u32 {
+    match mode {
+        LocalApicMode::XApic { xapic_base: _ } => actual_id << 24,
+        LocalApicMode::X2Apic => actual_id,
+    }
+}

--- a/src/lapic/mod.rs
+++ b/src/lapic/mod.rs
@@ -143,11 +143,21 @@ impl LocalApic {
         self.regs.tccr() as u32
     }
 
-    /// Sets the logical x2APIC ID.
+    /// Sets the logical xAPIC ID.
+    /// This can only be set in xAPIC mode.
+    /// IN x2APIC mode, this is read-only.
+    pub unsafe fn set_logical_id(&mut self, dest: u32) {
+        if let LocalApicMode::X2Apic = self.mode {
+            panic!("Cannot set the logical id because LDR is read-only in x2APIC mode.")
+        }
+        self.regs.write_ldr(encode_lapic_id(dest, self.mode));
+    }
+
+    /// Gets the logical x2APIC ID.
     ///
     /// This is used when the APIC is in logical mode.
-    pub unsafe fn set_logical_id(&mut self, dest: u32) {
-        self.regs.write_ldr(dest);
+    pub fn get_logical_id(&mut self) -> u32 {
+        decode_lapic_id(unsafe { self.regs.ldr() }, self.mode)
     }
 
     /// Sends an IPI to the processor(s) in `dest`.


### PR DESCRIPTION
⚠️ This only fixes the `id` and `send_nmi` methods. Other methods may need encoding / decoding too ⚠️

Fixes #19. @lihanrui2913 can u review this plz?

Also can u check if the `send_ipi` and similar methods also need to go through `encode_lapic_id`?